### PR TITLE
Adding apps

### DIFF
--- a/templates/app/$app/priv/www/index.html
+++ b/templates/app/$app/priv/www/index.html
@@ -1,0 +1,7 @@
+<html>
+  <head>
+  </head>
+  <body>
+    <h1>Hello world</h1>
+  </body>
+</html>

--- a/templates/app/$app/release-files/sys.config
+++ b/templates/app/$app/release-files/sys.config
@@ -1,0 +1,17 @@
+[
+  { $app,
+          [
+            { mode, dev },
+            { web_port, 3000 },
+            { modes,
+              [
+                {live, [
+                       {web_port, 8080}
+                  ]
+                }
+              ]
+            }
+          ]
+    }
+].
+

--- a/templates/app/$app/relx.config
+++ b/templates/app/$app/relx.config
@@ -1,0 +1,6 @@
+{release, {$app, "1.0.0"}, [$app]}.
+{lib_dirs, ["../../deps", "../"]}.
+{extended_start_script, true}.
+{sys_config, "release-files/sys.config"}.
+{include_src, false}.
+{overlay, [ ]}.

--- a/templates/app/$app/src/$app.app.src
+++ b/templates/app/$app/src/$app.app.src
@@ -1,0 +1,20 @@
+{application, $app,
+ [
+  {description, ""},
+  {vsn, "1.0.0"},
+  {registered, []},
+  {modules, []},
+  {included_applications, []},
+  {applications,
+   [
+    kernel,
+    jsx,
+    stdlib,
+    lager,
+    cowboy,
+    gproc,
+    shared
+   ]},
+  {mod, { $app_app, []}},
+  {env, []}
+  ]}.

--- a/templates/app/$app/src/$app_app.erl
+++ b/templates/app/$app/src/$app_app.erl
@@ -1,0 +1,50 @@
+-module($app_app).
+
+-behaviour(application).
+
+%% Application callbacks
+-export([start/2, stop/1]).
+
+
+%% ===================================================================
+%% Application callbacks
+%% ===================================================================
+
+start(_StartType, _StartArgs) ->
+  rewrite_config(),
+
+  Endpoints =
+  [
+   {"/[...]", cowboy_static, {priv_dir, $app, <<"www">>}}
+  ],
+
+  Dispatch = cowboy_router:compile([
+                                    {'_', lists:flatten(Endpoints)}
+                                   ]),
+
+  {ok, _} = cowboy:start_http(cowboy_http_listener, 5,
+                              [{port, $app_config:web_port()}],
+                              [{env, [{dispatch, Dispatch}]}
+                              ])
+  %% Start supervisors here
+  %%
+  .
+
+
+stop(_State) ->
+  ok.
+
+rewrite_config() ->
+  case application:get_env($app, mode) of
+    undefined -> ok;
+    {ok, Mode} ->
+      {ok, Modes} = application:get_env($app, modes),
+      case lists:keyfind(Mode, 1, Modes) of
+        { Mode, Config } ->
+                          lists:foreach(fun({Par, Val}) -> application:set_env($app, Par, Val) end, Config),
+                          application:set_env($app, modes, undefined);
+        false -> io:format(user, "Mode ~p not found ~n", [Mode])
+      end
+  end.
+
+

--- a/templates/app/$app/src/$app_config.erl
+++ b/templates/app/$app/src/$app_config.erl
@@ -1,0 +1,17 @@
+-module($app_config).
+
+-export([
+         web_port/0
+        ]).
+
+web_port() ->
+  get_value(web_port).
+
+get_value(Name) ->
+  gproc:get_env(l, $app, Name, [os_env, app_env, error]).
+
+get_value(Name, Default) ->
+  gproc:get_env(l, $app, Name, [os_env, app_env, {default, Default}]).
+
+
+

--- a/vir
+++ b/vir
@@ -27,11 +27,16 @@ munge_files() {
 }
 
 template_files() {
-  local app=$1
+  local arrayname=$1[@]
+  local files=("${!arrayname}")
   local variable=$2
   local value=$3
-  local MATCH="s/\$$variable/$APP_NAME/g"
-  $(find $TARGET_DIR -type f -exec sed -i $MATCH {} \;)
+  local MATCH="s/\$$variable/$value/g"
+
+  for file in ${files[@]}
+  do
+    $(find $file -type f -exec sed -i "" $MATCH {} \;)
+  done
 }
 
 make_bootscript() {
@@ -190,11 +195,21 @@ init() {
   fi
   echo "initing $APP_NAME with template: $TEMPLATE"
   cp -r $TEMPLATEDIR/$TEMPLATE/* $TARGET_DIR
+
   munge_files
-  template_files $TARGET_DIR  "app" $APP_NAME
+
   cd $TARGET_DIR
-  make
-  make_bootscript
+
+  files_copied=($TEMPLATEDIR/$TEMPLATE/*)
+  files_copied_no_path=(${files_copied[@]#$TEMPLATEDIR/$TEMPLATE/})
+  files_copied_munged=(${files_copied_no_path[@]/\$app/$APP_NAME/})
+
+  template_files files_copied_munged "app" $APP_NAME
+
+  if [[ -f makefile ]]; then
+    make
+    make_bootscript
+  fi
 }
 
 usage() {


### PR DESCRIPTION
Added app template and tweaks to init / template_files to allow adding an app to an existing project.  Main change was to tweak template_files so it only processed the directories / files that got copied from the template rather than everything.  To run on an existing project is:

```
~/.vir/vir init -t app -d ~/Projects/foo/apps myapp2
```

It's not perfect, since it could maybe be smarter and find the existing makefile, run it and run make_bootscript, but it's a start...
