### PR TITLE
using which to get the fully qualified path to the script.

### DIFF
--- a/autoextract.sh
+++ b/autoextract.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ThisFile="$PWD/$0"
+ThisFile="$(which $0)"
 
 # search for the line number where script finishes and the tarball starts
 LinesToSkip=$(awk '/^__TARFILE_FOLLOWS__/ { print NR + 1; exit 0; }' $0)


### PR DESCRIPTION
$0 takes the script name as typed, so combining that with the current working dir gives an incorrect result if the invoked path has some directory information.
